### PR TITLE
Fix search bar width on narrow mobile screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,6 +230,9 @@
         header h1 {
           font-size: 16px;
         }
+        .search {
+          width: 150px;
+        }
         footer {
           flex-direction: column;
           align-items: center;


### PR DESCRIPTION
This commit adjusts the width of the search input field on mobile devices. The previous fixed width could cause horizontal overflow on very narrow screens. The width is now reduced to ensure it fits within the viewport.